### PR TITLE
Fix - Support binaries for box image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cumulocity-asset-viewer-widget",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/gp-asset-viewer/src/lib/gp-asset-viewer.component.html
+++ b/projects/gp-asset-viewer/src/lib/gp-asset-viewer.component.html
@@ -97,10 +97,12 @@
              <div class="heading" title="{{ndevice.name}}">{{ndevice.name}}</div>
              <div class="display-text">Device Id:{{ndevice.id}}</div>
              <div class="device-header-image">
-                 <span
+                 <span 
+                   *ngIf="ndevice._boxImage"
                    (click)="navigateURL( ndevice.id, ndevice.type);
                    ndevice.switchToDashboard = true;"><img
-                   [src]="getImage(ndevice.image)"></span>
+                   [src]="ndevice._boxImage"></span>
+                   <c8y-loading *ngIf="!ndevice._boxImage"></c8y-loading>
              </div>
              
               <div class="display-text" *ngIf="ndevice.deviceExternalDetails" title="

--- a/projects/gp-asset-viewer/src/lib/gp-asset-viewer.component.ts
+++ b/projects/gp-asset-viewer/src/lib/gp-asset-viewer.component.ts
@@ -476,6 +476,8 @@ export class GpAssetViewerComponent implements OnInit, OnDestroy {
       this.sanitizer.bypassSecurityTrustResourceUrl(this.defaultImageURL);
     }
 
+    // if content of image variable is a number it is assumed it is a binary id
+    // and therefore the corresponding image is loaded from the binary repository
     if (image && Number(image)) {
       const response = await  this.deviceListService.downloadBinary(image) as Response;
       const binaryBlob = await response.blob();

--- a/projects/gp-asset-viewer/src/lib/gp-asset-viewer.module.ts
+++ b/projects/gp-asset-viewer/src/lib/gp-asset-viewer.module.ts
@@ -17,7 +17,7 @@
  */
 
 import { NgModule } from '@angular/core';
-import { CoreModule, HOOK_COMPONENTS } from '@c8y/ngx-components';
+import { CommonModule, CoreModule, HOOK_COMPONENTS } from '@c8y/ngx-components';
 import * as preview from './preview-image';
 import { GpAssetViewerComponent } from './gp-asset-viewer.component';
 import { GpAssetViewerService } from './gp-asset-viewer.service';
@@ -34,6 +34,7 @@ import { PaginationModule } from 'ngx-bootstrap/pagination';
   declarations: [GpAssetViewerComponent, GpAssetViewerConfigComponent],
   imports: [
     CoreModule,
+    CommonModule,
     FormsModule,
     ReactiveFormsModule,
     MatTableModule,


### PR DESCRIPTION
Add support for images stored as a binary in Cumulocity. The corresponding binary id of the image needs to be stored in the `image` of the respective ManagedObject. The widget will check if it is a base64 image or a binary image and displays it accordingly. Use the `c8y-loading` component to display a loading indicator.